### PR TITLE
Refactor input and CPU updates

### DIFF
--- a/client/src/game/CPUUpdater.ts
+++ b/client/src/game/CPUUpdater.ts
@@ -1,0 +1,44 @@
+import { CPUController, CPUDifficulty } from "./CPU";
+import { CharacterState } from "../lib/stores/useFighting";
+
+export class CPUUpdater {
+  private controller: CPUController;
+
+  constructor(difficulty: CPUDifficulty = CPUDifficulty.MEDIUM) {
+    this.controller = new CPUController(difficulty);
+  }
+
+  update(
+    cpu: CharacterState,
+    player: CharacterState,
+    moveCPU: (x: number, y: number, z: number) => void,
+    updateCPUVelocity: (vx: number, vy: number, vz: number) => void,
+    setCPUDirection: (direction: 1 | -1) => void,
+    setCPUJumping: (jumping: boolean) => void,
+    setCPUAttacking: (attacking: boolean) => void,
+    setCPUBlocking: (blocking: boolean) => void,
+    setCPUDodging?: (dodging: boolean) => void,
+    setCPUGrabbing?: (grabbing: boolean) => void,
+    setCPUTaunting?: (taunting: boolean) => void,
+    setCPUAirAttacking?: (airAttacking: boolean) => void,
+    resetCPUAirJumps?: () => void,
+    useCPUAirJump?: () => boolean
+  ) {
+    this.controller.update(
+      cpu,
+      player,
+      moveCPU,
+      updateCPUVelocity,
+      setCPUDirection,
+      setCPUJumping,
+      setCPUAttacking,
+      setCPUBlocking,
+      setCPUDodging,
+      setCPUGrabbing,
+      setCPUTaunting,
+      setCPUAirAttacking,
+      resetCPUAirJumps,
+      useCPUAirJump
+    );
+  }
+}

--- a/client/src/game/GameManager.tsx
+++ b/client/src/game/GameManager.tsx
@@ -3,7 +3,8 @@ import { useEffect, useRef, useState } from "react";
 import { useFighting } from "../lib/stores/useFighting";
 import StickFigure from "./StickFigure";
 import Arena from "./Arena";
-import { CPUController, CPUDifficulty } from "./CPU";
+import { CPUDifficulty } from "./CPU";
+import { CPUUpdater } from "./CPUUpdater";
 import { 
   checkAttackHit, 
   PUNCH_DAMAGE, 
@@ -20,8 +21,7 @@ import {
   isOnPlatform
 } from "./Physics";
 import { useControls } from "../lib/stores/useControls";
-import { useKeyboardControls } from "@react-three/drei";
-import { Controls } from "../lib/stores/useControls";
+import { usePlayerControls } from "../hooks/use-player-controls";
 import { useAudio } from "../lib/stores/useAudio";
 
 const GameManager = () => {
@@ -79,17 +79,14 @@ const GameManager = () => {
     playSuccess
   } = useAudio();
 
-  // Initialize CPU controller
-  const [cpuController] = useState(() => new CPUController(CPUDifficulty.MEDIUM));
+  // Initialize CPU updater
+  const [cpuUpdater] = useState(() => new CPUUpdater(CPUDifficulty.MEDIUM));
   
   // Refs for timing
   const lastFrameTime = useRef(Date.now());
   
-  // Get keyboard state
-  const [, getKeyboardState] = useKeyboardControls<Controls>();
-  
-  // Extract the forward key state directly from the keyboard controls
-  const forwardKey = useKeyboardControls(state => state.forward);
+  // Get keyboard state through custom hook
+  const getKeyboardState = usePlayerControls();
   
   // Combat system
   useEffect(() => {
@@ -450,7 +447,7 @@ const GameManager = () => {
     }
     
     // Update CPU behavior with all Smash Bros style actions
-    cpuController.update(
+    cpuUpdater.update(
       cpu,
       player,
       moveCPU,

--- a/client/src/hooks/use-player-controls.tsx
+++ b/client/src/hooks/use-player-controls.tsx
@@ -1,0 +1,8 @@
+import { useCallback } from "react";
+import { useKeyboardControls } from "@react-three/drei";
+import { Controls } from "../lib/stores/useControls";
+
+export function usePlayerControls() {
+  const [, get] = useKeyboardControls<Controls>();
+  return useCallback(() => get(), [get]);
+}


### PR DESCRIPTION
## Summary
- create a `usePlayerControls` hook for reading keyboard state
- add `CPUUpdater` module to manage CPU logic
- simplify `GameManager` to use these modules

## Testing
- `npm run check` *(fails: Cannot find type definition file)*

------
https://chatgpt.com/codex/tasks/task_e_6840a75dd718832fb70f57bf76dc2309