### PR TITLE
Scale physics by frame delta

### DIFF
--- a/client/src/game/CPU.ts
+++ b/client/src/game/CPU.ts
@@ -183,7 +183,8 @@ export class CPUController {
     onTauntingChange?: (isTaunting: boolean) => void,
     onAirAttackingChange?: (isAirAttacking: boolean) => void,
     resetAirJumps?: () => void,
-    useAirJump?: () => boolean
+    useAirJump?: () => boolean,
+    delta: number = 1
   ) {
     // Decrease action timer
     this.actionTimer--;
@@ -347,8 +348,8 @@ export class CPUController {
         
       default: // IDLE
         // Apply drag to both X and Z axes for 3D movement
-        newVX = applyDrag(newVX);
-        newVZ = applyDrag(newVZ); // Also slow down Z movement when idle
+        newVX = applyDrag(newVX, delta);
+        newVZ = applyDrag(newVZ, delta); // Also slow down Z movement when idle
         
         // Reset blocking
         if (isBlocking) {
@@ -362,13 +363,13 @@ export class CPUController {
     }
     
     // Apply gravity with platform collision detection
-    const [newY, newVY] = applyGravity(y, vy, x, z);
+    const [newY, newVY] = applyGravity(y, vy, x, z, false, delta);
     
     // Calculate the new X position, staying within arena bounds
-    const newX = stayInArena(x + newVX);
+    const newX = stayInArena(x + newVX * delta);
     
     // Calculate the new Z position with 3D boundary checks
-    const newZ = stayInArenaZ(z + newVZ);
+    const newZ = stayInArenaZ(z + newVZ * delta);
     
     // Update positions and velocities with 3D movement support
     onPositionChange(newX, newY, newZ);

--- a/client/src/game/CPUUpdater.ts
+++ b/client/src/game/CPUUpdater.ts
@@ -22,7 +22,8 @@ export class CPUUpdater {
     setCPUTaunting?: (taunting: boolean) => void,
     setCPUAirAttacking?: (airAttacking: boolean) => void,
     resetCPUAirJumps?: () => void,
-    useCPUAirJump?: () => boolean
+    useCPUAirJump?: () => boolean,
+    delta: number = 1
   ) {
     this.controller.update(
       cpu,
@@ -38,7 +39,8 @@ export class CPUUpdater {
       setCPUTaunting,
       setCPUAirAttacking,
       resetCPUAirJumps,
-      useCPUAirJump
+      useCPUAirJump,
+      delta
     );
   }
 }

--- a/client/src/game/GameManager.tsx
+++ b/client/src/game/GameManager.tsx
@@ -156,6 +156,11 @@ const GameManager = () => {
   // Handle player keyboard controls directly with 3D Smash Bros style movement
   useFrame(() => {
     if (gamePhase !== 'fighting') return;
+
+    // Calculate time delta in seconds at the start of the frame
+    const now = Date.now();
+    const delta = (now - lastFrameTime.current) / 1000;
+    lastFrameTime.current = now;
     
     // Get current keyboard state with the new control scheme
     const { 
@@ -262,7 +267,7 @@ const GameManager = () => {
       console.log("Player dropping through platform at height:", platformHeight);
     }
     
-    const [newY, gravityVY] = applyGravity(playerY, newVY, playerX, playerZ, dropThrough);
+    const [newY, gravityVY] = applyGravity(playerY, newVY, playerX, playerZ, dropThrough, delta);
     newVY = gravityVY; // Update with gravity effect
     
     // Update jumping state when landing on a platform or ground
@@ -412,21 +417,17 @@ const GameManager = () => {
     }
     
     // Calculate the new X position, staying within arena bounds
-    const newX = stayInArena(playerX + newVX);
+    const newX = stayInArena(playerX + newVX * delta);
     
     // Calculate the new Z position, staying within arena bounds - NEW 3D MOVEMENT
-    const newZ = stayInArenaZ(playerZ + newVZ);
+    const newZ = stayInArenaZ(playerZ + newVZ * delta);
     
     // Update player position and velocity with 3D movement
     movePlayer(newX, newY, newZ);
     updatePlayerVelocity(newVX, newVY, newVZ);
     
     // Main game update loop
-    // Calculate time delta in seconds
-    const now = Date.now();
-    const delta = (now - lastFrameTime.current) / 1000;
-    lastFrameTime.current = now;
-    
+
     // Update game time
     updateRoundTime(delta);
     
@@ -462,7 +463,8 @@ const GameManager = () => {
       setCPUTaunting,
       setCPUAirAttacking,
       resetCPUAirJumps,
-      useCPUAirJump
+      useCPUAirJump,
+      delta
     );
   });
   

--- a/client/src/game/Physics.ts
+++ b/client/src/game/Physics.ts
@@ -158,12 +158,19 @@ export function getPlatformHeight(x: number, z: number): number {
  * Applies gravity to a vertical position and velocity,
  * with platform collision detection
  */
-export function applyGravity(y: number, velocityY: number, x: number = 0, z: number = 0, dropThrough: boolean = false): [number, number] {
-  // Apply gravity to the velocity
-  const newVelocityY = velocityY - GRAVITY;
-  
-  // Calculate new position
-  const newY = y + newVelocityY;
+export function applyGravity(
+  y: number,
+  velocityY: number,
+  x: number = 0,
+  z: number = 0,
+  dropThrough: boolean = false,
+  delta: number = 1
+): [number, number] {
+  // Apply gravity to the velocity scaled by delta
+  const newVelocityY = velocityY - GRAVITY * delta;
+
+  // Calculate new position scaled by delta
+  const newY = y + newVelocityY * delta;
   
   // Find the height of the platform at the current x,z position
   const platformHeight = getPlatformHeight(x, z);
@@ -215,8 +222,10 @@ export function stayInArenaZ(z: number): number {
 /**
  * Apply drag to velocity to slow down over time
  */
-export function applyDrag(velocity: number): number {
-  return velocity * DRAG;
+export function applyDrag(velocity: number, delta: number = 1): number {
+  // Linearly scale drag effect by delta
+  const dragFactor = 1 - (1 - DRAG) * delta;
+  return velocity * dragFactor;
 }
 
 /**


### PR DESCRIPTION
## Summary
- update gravity and drag helpers to take `delta`
- use delta when moving CPU and player characters
- pass delta through CPU update pipeline

## Testing
- `npm run check` *(fails: missing type definitions and other errors)*
- `npm run test` *(fails: no test script)*

------
https://chatgpt.com/codex/tasks/task_e_6840a9043ce8832f824fc6d4c12b05a0